### PR TITLE
Add correct siteUrl to gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 const pathPrefix = '/' // Prefix for all links. If you deploy your site to example.com/blog your pathPrefix should be "blog"
 const siteTitle = 'swyx.io' // Navigation and Site Title
-const siteUrl = 'https://your-site.io' // Domain of your site. No trailing slash!
+const siteUrl = 'https://www.swyx.io' // Domain of your site. No trailing slash!
 const siteLogo = 'swyx.jpg' // Used for SEO and manifest, path to your image you placed in the 'static' folder
 const siteDescription = 'Personal site for shawn swyx wang'
 module.exports = {


### PR DESCRIPTION
Fixes Twitter / Facebook share url:

![Screen Shot 2019-08-22 at 12 31 04 pm](https://user-images.githubusercontent.com/3147296/63481698-9cda2480-c4d9-11e9-9d65-8badafb77381.png)

I don't know if you prefer the `www` or not 😅