### PR TITLE
Fix web mentions link overflow on home page

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -131,6 +131,9 @@
   .PostHeader {
     background-color: var(--bg-color-secondary);
   }
+  .PostHeader a {
+    overflow-wrap: break-word;
+  }
 </style>
 
 <svelte:head>


### PR DESCRIPTION
Web mention links on the home page overflow on mobile devcies:

![](https://user-images.githubusercontent.com/10463157/79037302-0ecdbe00-7bd0-11ea-9797-028360f10114.png)

I fixed the issue by adding `overflow-wrap: break-word;` to the anchor element:

![](https://user-images.githubusercontent.com/10463157/79037339-4177b680-7bd0-11ea-972e-86e4bdc360f0.png)

