### PR TITLE
Add better Support for Linux Color Emoji

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -39,7 +39,7 @@
       body {
         margin: 0;
         font-family: Roboto, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-          Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+          Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Noto Color Emoji', 'Segoe UI Emoji',
           'Segoe UI Symbol';
         font-weight: 400;
         font-size: 1.2rem;
@@ -128,7 +128,7 @@
       h3,
       h4 {
         font-family: Rajdhani, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-          Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+          Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Noto Color Emoji', 'Segoe UI Emoji',
           'Segoe UI Symbol';
         margin: 0;
         margin-top: 20px;


### PR DESCRIPTION
Using Chrome On Fedora Linux

before 
![image](https://user-images.githubusercontent.com/119011/81854926-492bd180-9567-11ea-953e-4f180e8ca2f9.png)
after
![image](https://user-images.githubusercontent.com/119011/81854978-5943b100-9567-11ea-9aaa-1917e9bb5e93.png)
