### PR TITLE
fix: Accessible name for webmentions article link

### DIFF
--- a/src/components/WebMentions.svelte
+++ b/src/components/WebMentions.svelte
@@ -104,6 +104,7 @@
 <div id="WebMentions">
   <h3 font-family="system" font-size="4" font-weight="bold">Webmentions</h3>
   <a
+    aria-label="Clientside Webmentions"
     target="_blank"
     rel="noopener"
     href="http://swyx.io/writing/clientside-webmentions"


### PR DESCRIPTION
Otherwise assistive technology reads out the full link. See https://web.dev/link-name/ or https://dequeuniversity.com/rules/axe/3.0/link-name for more information.