### PR TITLE
Make links clickable in blockquotes

### DIFF
--- a/src/routes/_slug.svelte
+++ b/src/routes/_slug.svelte
@@ -65,6 +65,7 @@
     left: 0;
     background-color: var(--link-color);
     opacity: 0.1;
+    pointer-events: none;
   }
   .content :global(a) {
     border-bottom: 2px solid #F26111;


### PR DESCRIPTION
Fixes #38 by disabling `pointer-events` on the blockquote's `::before` :)