### PR TITLE
Make RSS feeds discoverable

### DIFF
--- a/src/routes/home/Home.svelte
+++ b/src/routes/home/Home.svelte
@@ -1,6 +1,7 @@
 <svelte:head>
   <title>swyx's site</title>
   <link rel="canonical" href="https://www.swyx.io/" />
+  <link rel="alternate" type="application/rss+xml" href="https://swyx.io/rss.xml" />
   <meta property="og:url" content="https://www.swyx.io/" />
   <meta property="og:type" content="article" />
   <meta property="og:title" content="swyx.io home" />

--- a/src/routes/ideas/Ideas.svelte
+++ b/src/routes/ideas/Ideas.svelte
@@ -13,6 +13,7 @@
 <svelte:head>
   <title>swyx | Ideas</title>
   <link rel="canonical" href="https://www.swyx.io/ideas/" />
+  <link rel="alternate" type="application/rss+xml" href="https://swyx.io/rss.xml" />
   <meta property="og:url" content="https://www.swyx.io/ideas/" />
   <meta property="og:type" content="article" />
   <meta property="og:title" content="swyx | Ideas" />

--- a/src/routes/subscribe/Subscribe.svelte
+++ b/src/routes/subscribe/Subscribe.svelte
@@ -6,6 +6,7 @@
   
   <svelte:head>
     <title>swyx's Newsletter</title>
+    <link rel="alternate" type="application/rss+xml" href="https://swyx.io/rss.xml" />
     <meta property="og:url" content={'https://swyx.io/newsletter'} />
     <meta property="og:type" content="article" />
     <meta property="og:title" content={title} />


### PR DESCRIPTION
To allow folks to subscribe to this site using their feed readers, we
can add the `rel=alternate` link to the page metadata for the home,
ideas and subscribe pages.