### PR TITLE
fix rss link in footer

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,19 +1,10 @@
 <script context="module">
 	import { MY_TWITTER, MY_YOUTUBE, REPO_URL } from '$lib/siteConfig';
-	/** @type {import('@sveltejs/kit').Load} */
-	export async function load({ url }) {
-		return {
-			props: {
-				origin: url.origin
-			}
-		};
-	}
 </script>
 
 <script>
 	import '../tailwind.css';
 	import Nav from '../components/Nav.svelte';
-	export let origin = '';
 </script>
 
 <link rel="webmention" href="https://webmention.io/www.swyx.io/webmention" />
@@ -37,7 +28,7 @@
 			<a class="text-gray-500 transition hover:text-gray-300" href="/subscribe">Newsletter</a>
 			<a
 				class="text-gray-500 transition hover:text-gray-300"
-				href={origin + '/api/rss.xml'}
+				href="/api/rss.xml"
 				rel="external">RSS</a
 			>
 		</div>


### PR DESCRIPTION
Since the homepage is prerendered, currently the rss link is thinking it's hosted on `http://prerender/api/rss.xml` which breaks the link. This removes the origin stuff as in my testing it made no difference whether it was a fully qualified href