### PR TITLE
fix default opengraph image

### DIFF
--- a/src/lib/siteConfig.js
+++ b/src/lib/siteConfig.js
@@ -4,7 +4,7 @@ export const REPO_URL = 'https://github.com/' + GH_USER_REPO;
 export const SITE_TITLE = "swyx's site";
 export const SITE_DESCRIPTION =
 	'The official site of Shawn @swyx Wang, a technologist and recovering finance geek.';
-export const DEFAULT_OG_IMAGE = 'swyx-ski.jpeg';
+export const DEFAULT_OG_IMAGE = SITE_URL + '/swyx-ski.jpeg';
 export const MY_TWITTER_HANDLE = 'swyx';
 export const MY_YOUTUBE = 'https://youtube.com/swyxTV?sub_confirmation=1';
 


### PR DESCRIPTION
- The open graph image currently points to `https://swyx.iosyx-ski.jpeg`, whereas it should be `https://swyx.io/swyx-ski.jpeg`
- Update `siteConfig.DEFAULT_OG_IMAGE` with proper trailing slash and `SITE_URL` to make sure the correct link is used
- Example here with the broken image link: https://www.opengraph.xyz/url/https%3A%2F%2Fswyx.io%2F