### PR TITLE
Fix links in speaking engagements section

### DIFF
--- a/src/components/FeaturedSpeaking.svx
+++ b/src/components/FeaturedSpeaking.svx
@@ -11,7 +11,7 @@ The JS/Beginner Era:
 - **[Getting Closure on Hooks](/hooks)**: My most well received technical talk, where I explain a mental model for React hooks by livecoding a React clone at JSConf Asia. Started as [a tweet](https://twitter.com/swyx/status/1100809424963219456), then [a blogpost.](https://www.swyx.io/writing/getting-closure-on-hooks/)
 - **[Why React is not Reactive](/reactrally)**: My first conference talk ever was at the biggest React venue in the world, React Rally. I spent a month writing [my CFP on the most interesting React question I could think of](https://twitter.com/swyx/status/1112513571315830784?s=20).
 - **[Contributing to React](/ideas?filter=contributing%20to%20react)**: My first meetup talk ever was at React NYC - this was accepted on to the React docs as a guide for other contributors!
-- **[Learn In Public](/ideas?filter=learn%20in%20public&show=Talks&show=Tutorials&show=Notes)**: My first verbal exposition on the Learn In Public philosophy. Video is frozen at the end, sorry.
-- **[I Can Babel Macros and So Can You! (the Moana talk)](/ideas?filter=babel%20macros&show=Talks)**: My first JSConf appearance ever, at one of the most competitive JSConfs ever. This talk is where I first started experimenting with theming talks, and it came out really well with the Moana theme.
+- **[Learn In Public](/ideas?filter=learn%20in%20public&show=Note%2CTalk%2CTutorial)**: My first verbal exposition on the Learn In Public philosophy. Video is frozen at the end, sorry.
+- **[I Can Babel Macros and So Can You! (the Moana talk)](/ideas?filter=babel%20macros&show=Talk)**: My first JSConf appearance ever, at one of the most competitive JSConfs ever. This talk is where I first started experimenting with theming talks, and it came out really well with the Moana theme.
 
-[More of my speaking on the /ideas page](/ideas/?show=Talks&show=Podcasts).
+[More of my speaking on the /ideas page](/ideas/?show=Talk%2CPodcast).


### PR DESCRIPTION
The values for `show` were incorrectly pluralized, causing the ideas page to show no content.

Ex: `Talks` => `Talk`,  `Tutorials` => `Tutorial`,  `Notes` => `Note`